### PR TITLE
Removed an imported symbol (stream-close) for ABCL that does not exist.

### DIFF
--- a/lisp-dep/packages.lisp
+++ b/lisp-dep/packages.lisp
@@ -58,7 +58,6 @@
                 #+lispworks #:stream-read-buffer
                 #+lispworks #:stream-fill-buffer
                 #+lispworks #:stream-flush-buffer
-		#+abcl #:stream-close
                 #+lispworks #:with-stream-input-buffer
                 #+lispworks #:with-stream-output-buffer)
   (:export 


### PR DESCRIPTION
I have created an issue but I think that this is the "github" way ;)
