### PR TITLE
Import the :gray package in ECL

### DIFF
--- a/lisp-dep/packages.lisp
+++ b/lisp-dep/packages.lisp
@@ -32,6 +32,7 @@
   (:use :cl)
   (:import-from #+lispworks :stream #+cmu :lisp #+clisp :gray #+cormanlisp :gray-streams
                 #+openmcl :ccl #+mcl :ccl #+allegro :excl #+sbcl :sb-gray #+abcl :gray-streams
+                #+ecl :gray
                 #:fundamental-binary-input-stream
                 #:fundamental-binary-output-stream
                 #:fundamental-character-input-stream


### PR DESCRIPTION
Without this, ECL fails on load with:

``` lisp
;;; Error:
;;;   in file packages.lisp, position 1442
;;;   at (defpackage mel.gray-stream ...)
;;;   * The form (si::dodefpackage "MEL.GRAY-STREAM" 'nil nil '("CL") 'nil 'nil '("FUNDAMENTAL-BINARY-INPUT-STREAM" "FUNDAMENTAL-BINARY-OUTPUT-STREAM" "FUNDAMENTAL-CHARACTER-INPUT-STREAM" "FUNDAMENTAL-CHARACTER-OUTPUT-STREAM" "STREAM-ELEMENT-TYPE" "STREAM-LISTEN" "STREAM-READ-BYTE" "STREAM-READ-CHAR" "STREAM-WRITE-BYTE" "STREAM-WRITE-CHAR" "STREAM-READ-CHAR-NO-HANG" "STREAM-FORCE-OUTPUT" "STREAM-FINISH-OUTPUT" "STREAM-CLEAR-INPUT" "STREAM-CLEAR-OUTPUT" "STREAM-LINE-COLUMN" "STREAM-READ-SEQUENCE" "STREAM-UNREAD-CHAR" "STREAM-READ-LINE" "STREAM-WRITE-SEQUENCE" "STREAM-WRITE-STRING" "STREAM-WRITE-BUFFER" "STREAM-READ-BUFFER" "STREAM-FILL-BUFFER" "STREAM-FLUSH-BUFFER" "WITH-STREAM-INPUT-BUFFER" "WITH-STREAM-OUTPUT-BUFFER") 'nil '(("FUNDAMENTAL-BINARY-INPUT-STREAM" "FUNDAMENTAL-BINARY-OUTPUT-STREAM" "FUNDAMENTAL-CHARACTER-INPUT-STREAM" "FUNDAMENTAL-CHARACTER-OUTPUT-STREAM" "STREAM-ELEMENT-TYPE" "STREAM-LISTEN" "STREAM-READ-BYTE" "STREAM-READ-CHAR" "STREAM-PEEK-CHAR" "STREAM-WRITE-BYTE" "STREAM-WRITE-CHAR" "STREAM-READ-CHAR-NO-HANG" "STREAM-FORCE-OUTPUT" "STREAM-FINISH-OUTPUT" "STREAM-CLEAR-INPUT" "STREAM-CLEAR-OUTPUT" "STREAM-LINE-COLUMN" "STREAM-READ-SEQUENCE" "STREAM-UNREAD-CHAR" "STREAM-READ-LINE" "STREAM-WRITE-SEQUENCE" "STREAM-WRITE-STRING")) 'nil) was not evaluated successfully.
;;; Error detected:
;;; There exists no package with name nil
Condition of type: COMPILE-FILE-ERROR
COMPILE-FILE-ERROR while ...

```
