### PR TITLE
Return a flexi-stream from make-imap-connection (like for make-imaps-connection)

### DIFF
--- a/lisp-dep/network.lisp
+++ b/lisp-dep/network.lisp
@@ -42,7 +42,7 @@
   (if (or (and ssl-p ssl)
 	  (and (not ssl-p) (ssl-default port)))
       (make-ssl-connection fd)
-      fd))
+      (flexi-streams:make-flexi-stream fd :external-format :iso-8859-1)))
 
 (defun ssl-default (port)
   (member port '(993 995 465 585)))


### PR DESCRIPTION
Without this, on SBCL 1.3.1 at least, make-imap-connection returns a binary stream, and subsequent read-char attempts fail.

This makes make-imap-connection consistent with make-imaps-connection.